### PR TITLE
Revert "Run apt-get update when sources are added."

### DIFF
--- a/manifests/backports.pp
+++ b/manifests/backports.pp
@@ -16,7 +16,6 @@ class apt_extras::backports {
     release           => "${::lsbdistcodename}-backports",
     repos             => 'main',
     required_packages => 'debian-keyring debian-archive-keyring',
-    notify            => Exec['apt-get-update'],
   }
 
 }

--- a/manifests/contrib.pp
+++ b/manifests/contrib.pp
@@ -9,7 +9,6 @@ class apt_extras::contrib {
     release           => $::lsbdistcodename,
     repos             => 'contrib',
     required_packages => 'debian-keyring debian-archive-keyring',
-    notify            => Exec['apt-get-update'],
   }
 
 }

--- a/manifests/dotdeb.pp
+++ b/manifests/dotdeb.pp
@@ -14,7 +14,6 @@ class apt_extras::dotdeb {
     repos             => 'all',
     required_packages => 'debian-keyring debian-archive-keyring',
     require           => Apt::Key['dotdeb'],
-    notify            => Exec['apt-get-update'],
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,10 +2,5 @@
 #
 class apt_extras {
 
-  exec {'apt-get-update':
-    command => 'apt-get update',
-    refreshonly => true,
-  }
-
 }
 

--- a/manifests/lts.pp
+++ b/manifests/lts.pp
@@ -10,7 +10,6 @@ class apt_extras::lts {
       release           => "${::lsbdistcodename}-lts",
       repos             => 'main contrib non-free',
       required_packages => 'debian-keyring debian-archive-keyring',
-      notify            => Exec['apt-get-update'],
     }
   }
 

--- a/manifests/nodesource.pp
+++ b/manifests/nodesource.pp
@@ -19,7 +19,6 @@ class apt_extras::nodesource {
     repos             => 'main',
     required_packages => 'debian-keyring debian-archive-keyring',
     require           => Apt::Key['nodesource'],
-    notify            => Exec['apt-get-update'],
   }
 
 }

--- a/manifests/nonfree.pp
+++ b/manifests/nonfree.pp
@@ -9,7 +9,6 @@ class apt_extras::nonfree {
     release           => $::lsbdistcodename,
     repos             => 'non-free',
     required_packages => 'debian-keyring debian-archive-keyring',
-    notify            => Exec['apt-get-update'],
   }
 
 }

--- a/manifests/phusionpassenger.pp
+++ b/manifests/phusionpassenger.pp
@@ -14,7 +14,6 @@ class apt_extras::phusionpassenger {
     repos             => 'main',
     required_packages => 'debian-keyring debian-archive-keyring',
     require           => Apt::Key['phusionpassenger'],
-    notify            => Exec['apt-get-update'],
   }
 
 }


### PR DESCRIPTION
Reverts sbitio/puppet-apt_extras#1.

puppetlabs/apt 2.3.0 already address this problem.